### PR TITLE
Bugfix CLI broken from v2.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,22 @@ jobs:
       with:
         name: junit test reports
         path: junit
+
+  cli_test:
+    strategy:
+      matrix:
+        container: ["node:current", "node:lts"]
+
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: npm ci
+    - run: npm run build
+
+    - name: Exec with no option
+      run: node ./dist/cli.js __tests__/fixtures/android-robolectric-success.xml
+    - name: Exec with --filter
+      run: node ./dist/cli.js -f system-out __tests__/fixtures/android-robolectric-success.xml | grep -v system-out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         container: ["node:current", "node:lts"]
+      fail-fast: false
 
     runs-on: ubuntu-latest
     container:
@@ -14,6 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Show node env
+      run: |
+        node -v
+        npm -v
     - run: npm ci
     - run: npm run test
     - uses: actions/upload-artifact@v2
@@ -25,6 +30,7 @@ jobs:
     strategy:
       matrix:
         container: ["node:current", "node:lts"]
+      fail-fast: false
 
     runs-on: ubuntu-latest
     container:
@@ -32,6 +38,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Show node env
+      run: |
+        node -v
+        npm -v
     - run: npm ci
     - run: npm run build
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ const argv = yargs
       p: { type: 'boolean', alias: 'pretty', describe: 'Output pretty JSON' },
       f: { type: 'string', alias: 'filter-tags', describe: 'Filter XML tag names' },
     })
-    yargs.coerce('f', (str) => str.split(','))
+    yargs.coerce('f', (filter?: string) => filter?.split(',') )
     yargs.positional('path', {
       describe: 'JUnit XML path',
       type: 'string'


### PR DESCRIPTION
CLI does not work with no `-f` options from v2.0.4
Newer yargs version may have breaking changes. https://github.com/Kesin11/ts-junit2json/pull/102