### PR TITLE
Strict typing

### DIFF
--- a/__tests__/basic.test.ts
+++ b/__tests__/basic.test.ts
@@ -29,7 +29,7 @@ describe('Convert xml2js output tests', () => {
         testsuite: [
           { failures: 1, tests: 2 },
         ]
-    })
+    } as junit2json.TestSuites)
   })
 
   it('array with string array', async () => {
@@ -37,7 +37,9 @@ describe('Convert xml2js output tests', () => {
     <?xml version="1.0" encoding="UTF-8"?>
     <testsuites>
       <testsuite tests="1">
-        <failure>inner text</failure>
+        <testcase>
+          <failure>inner text</failure>
+        </testcase>
       </testsuite>
     </testsuites>
     `
@@ -47,12 +49,14 @@ describe('Convert xml2js output tests', () => {
         testsuite: [
           {
             tests: 1,
-            failure: [
-              { inner: 'inner text' }
-            ]
+            testcase: [{
+              failure: [
+                { inner: 'inner text' }
+              ]
+            }],
           },
         ]
-    })
+    } as junit2json.TestSuites)
   })
 
   it('inner', async () => {
@@ -60,7 +64,9 @@ describe('Convert xml2js output tests', () => {
     <?xml version="1.0" encoding="UTF-8"?>
     <testsuites>
       <testsuite tests="1">
-        <failure name="hoge">failure text</failure>
+        <testcase>
+          <failure message="hoge">failure text</failure>
+        </testcase>
       </testsuite>
     </testsuites>
     `
@@ -69,12 +75,14 @@ describe('Convert xml2js output tests', () => {
     expect(parsed).toEqual({
       testsuite: [{
         tests: 1,
-        failure: [{
-          name: 'hoge',
-          inner: 'failure text'
-        }]
+        testcase: [{
+          failure: [{
+            message: 'hoge',
+            inner: 'failure text'
+          }]
+        }],
       }]
-    })
+    } as junit2json.TestSuites)
   })
 
   it('system-out', async () => {
@@ -96,7 +104,7 @@ describe('Convert xml2js output tests', () => {
           "system-out": [ "system out text" ]
         }],
       }]
-    })
+    } as junit2json.TestSuites)
   })
 
   it('system-error', async () => {
@@ -118,6 +126,6 @@ describe('Convert xml2js output tests', () => {
           "system-err": [ "system error text" ]
         }],
       }]
-    })
+    } as junit2json.TestSuites)
   })
 })

--- a/__tests__/basic.test.ts
+++ b/__tests__/basic.test.ts
@@ -1,6 +1,25 @@
 import * as junit2json from '../src/index'
 
 describe('Convert xml2js output tests', () => {
+  it('returns null when XML is empty', async () => {
+    const xml = `
+    <?xml version="1.0" encoding="UTF-8"?>
+    `
+    const parsed = await junit2json.parse(xml)
+
+    expect(parsed).toEqual(null)
+  })
+
+  it('returns undefined when XML is not a recognized element', async () => {
+    const xml = `
+    <?xml version="1.0" encoding="UTF-8"?>
+    <unrecognized />
+    `
+    const parsed = await junit2json.parse(xml)
+
+    expect(parsed).toEqual(undefined)
+  })
+
   it('basic', async () => {
     const xml = `
     <?xml version="1.0" encoding="UTF-8"?>

--- a/__tests__/basic.test.ts
+++ b/__tests__/basic.test.ts
@@ -20,6 +20,17 @@ describe('Convert xml2js output tests', () => {
     expect(parsed).toEqual(undefined)
   })
 
+  it('returns undefined when a property is absent', async () => {
+    const xml = `
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites>
+    </testsuites>
+    `
+    const parsed = await junit2json.parse(xml) as junit2json.TestSuite 
+
+    expect(parsed.name).toEqual(undefined)
+  })
+
   it('basic', async () => {
     const xml = `
     <?xml version="1.0" encoding="UTF-8"?>

--- a/__tests__/xml_format.test.ts
+++ b/__tests__/xml_format.test.ts
@@ -10,7 +10,7 @@ describe('Parse various xml format tests', () => {
       </testsuite>
     </testsuites>
     `
-    
+
     const parsed = await junit2json.parse(xml)
 
     expect(parsed).toEqual({
@@ -34,7 +34,7 @@ describe('Parse various xml format tests', () => {
           }]
         },
       ]
-    })
+    } as junit2json.TestSuites)
   })
 
   it('testsuite root', async () => {
@@ -44,7 +44,7 @@ describe('Parse various xml format tests', () => {
       </testcase>
     </testsuite>
     `
-    
+
     const parsed = await junit2json.parse(xml)
 
     expect(parsed).toEqual({
@@ -60,7 +60,7 @@ describe('Parse various xml format tests', () => {
         name: "testcase",
         time: 1
       }]
-    })
+    } as junit2json.TestSuite)
 
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,56 +1,62 @@
 import xml2js from 'xml2js'
 
-export type TestSuites = {
-  testsuite: TestSuite[]
-  name?: string
-  time?: number
-  tests?: number
-  failures?: number
-  errors?: number
-  disabled?: number
-}
+type Maybe<T> = T | null
 
-export type TestSuite = {
-  testcase: TestCase[]
-  name: string
-  tests: number
-  failures?: number
-  errors?: number
-  time?: number
-  disabled?: number
-  skipped?: number
-  timestamp?: string
-  hostname?: string
-  id?: string
-  package?: string
-  properties?: Array< {name: string, value: string } >
-  "system-out"?: string[]
-  "system-err"?: string[]
-}
+export type TestSuites = Readonly<{
+  testsuite?: Maybe<readonly TestSuite[]>
+  name?: Maybe<string>
+  time?: Maybe<number>
+  tests?: Maybe<number>
+  failures?: Maybe<number>
+  errors?: Maybe<number>
+  disabled?: Maybe<number>
+}>
 
-export type TestCase = {
-  name: string
-  classname: string
-  assertions?: number
-  time?: number
-  status?: string
-  skipped?: Array<{ message?: string }>
-  error?: Array<{ message?: string, type?: string, inner?: string }>
-  failure?: Array<{ message?: string, type?: string, inner?: string }>
-  "system-out"?: string[]
-  "system-err"?: string[]
-}
+export type TestCase = Readonly<{
+  name?: Maybe<string>
+  classname?: Maybe<string>
+  assertions?: Maybe<number>
+  time?: Maybe<number>
+  status?: Maybe<string>
+  skipped?: Maybe<readonly Skipped[]>
+  error?: Maybe<readonly Details[]>
+  failure?: Maybe<readonly Details[]>
+  "system-out"?: Maybe<string[]>
+  "system-err"?: Maybe<string[]>
+}>
 
-export const parse = async (xmlString: xml2js.convertableToString, xml2jsOptions?: xml2js.OptionsV2): Promise<TestSuites|TestSuite> => {
+export type TestSuite = Readonly<{
+  testcase?: Maybe<readonly TestCase[]>
+  name?: Maybe<string>
+  tests?: Maybe<number>
+  failures?: Maybe<number>
+  errors?: Maybe<number>
+  time?: Maybe<number>
+  disabled?: Maybe<number>
+  skipped?: Maybe<number>
+  timestamp?: Maybe<string>
+  hostname?: Maybe<string>
+  id?: Maybe<string>
+  package?: Maybe<string>
+  properties?: Maybe<readonly Property[]>
+  "system-out"?: Maybe<readonly string[]>
+  "system-err"?: Maybe<readonly string[]>
+}>
+
+export type Property = Readonly<{ name?: Maybe<string>, value?: Maybe<string> }>
+export type Skipped = Readonly<{ message?: Maybe<string> }>
+export type Details = Readonly<{ message?: Maybe<string>, type?: Maybe<string>, inner?: Maybe<string> }>
+
+export const parse = async (xmlString: xml2js.convertableToString, xml2jsOptions?: xml2js.OptionsV2): Promise<TestSuites|TestSuite|undefined> => {
   const options = xml2jsOptions ?? {
     attrValueProcessors: [xml2js.processors.parseNumbers]
   }
   const result = await xml2js.parseStringPromise(xmlString, options)
 
-  if (result['testsuites']) {
+  if ('testsuites' in result) {
     return _parse(result['testsuites']) as Promise<TestSuites>
   }
-  else {
+  else if('testsuite' in result) {
     return _parse(result['testsuite']) as Promise<TestSuite>
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,51 +1,49 @@
 import xml2js from 'xml2js'
 
-type Maybe<T> = T | null
-
 export type TestSuites = {
-  testsuite?: Maybe<TestSuite[]>
-  name?: Maybe<string>
-  time?: Maybe<number>
-  tests?: Maybe<number>
-  failures?: Maybe<number>
-  errors?: Maybe<number>
-  disabled?: Maybe<number>
+  testsuite?: TestSuite[]
+  name?: string
+  time?: number
+  tests?: number
+  failures?: number
+  errors?: number
+  disabled?: number
 }
 
 export type TestCase = {
-  name?: Maybe<string>
-  classname?: Maybe<string>
-  assertions?: Maybe<number>
-  time?: Maybe<number>
-  status?: Maybe<string>
-  skipped?: Maybe<Skipped[]>
-  error?: Maybe<Details[]>
-  failure?: Maybe<Details[]>
-  "system-out"?: Maybe<string[]>
-  "system-err"?: Maybe<string[]>
+  name?: string
+  classname?: string
+  assertions?: number
+  time?: number
+  status?: string
+  skipped?: Skipped[]
+  error?: Details[]
+  failure?: Details[]
+  "system-out"?: string[]
+  "system-err"?: string[]
 }
 
 export type TestSuite = {
-  testcase?: Maybe<TestCase[]>
-  name?: Maybe<string>
-  tests?: Maybe<number>
-  failures?: Maybe<number>
-  errors?: Maybe<number>
-  time?: Maybe<number>
-  disabled?: Maybe<number>
-  skipped?: Maybe<number>
-  timestamp?: Maybe<string>
-  hostname?: Maybe<string>
-  id?: Maybe<string>
-  package?: Maybe<string>
-  properties?: Maybe<Property[]>
-  "system-out"?: Maybe<string[]>
-  "system-err"?: Maybe<string[]>
+  testcase?: TestCase[]
+  name?: string
+  tests?: number
+  failures?: number
+  errors?: number
+  time?: number
+  disabled?: number
+  skipped?: number
+  timestamp?: string
+  hostname?: string
+  id?: string
+  package?: string
+  properties?: Property[]
+  "system-out"?: string[]
+  "system-err"?: string[]
 }
 
-export type Property = { name?: Maybe<string>, value?: Maybe<string> }
-export type Skipped = { message?: Maybe<string> }
-export type Details = { message?: Maybe<string>, type?: Maybe<string>, inner?: Maybe<string> }
+export type Property = { name?: string, value?: string }
+export type Skipped = { message?: string }
+export type Details = { message?: string, type?: string, inner?: string }
 
 export const parse = async (xmlString: xml2js.convertableToString, xml2jsOptions?: xml2js.OptionsV2): Promise<TestSuites|TestSuite|undefined|null> => {
   const options = xml2jsOptions ?? {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ export const parse = async (xmlString: xml2js.convertableToString, xml2jsOptions
   }
 }
 
-type ObjOrArray = {[key: string]: any } | Array<ObjOrArray>
+type ObjOrArray = Record<string, any> | Array<ObjOrArray>
 const _parse = (objOrArray: ObjOrArray): ObjOrArray => {
   if (Array.isArray(objOrArray)) {
     return objOrArray.map((_obj: ObjOrArray) => {
@@ -72,7 +72,7 @@ const _parse = (objOrArray: ObjOrArray): ObjOrArray => {
       return { inner: _obj }
     })
   }
-  let output: {[key: string]: any} = {}
+  let output: Record<string, any> = {}
   Object.keys(objOrArray).forEach((key) => {
     const nested = objOrArray[key]
     if (key === '$') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,31 +2,31 @@ import xml2js from 'xml2js'
 
 type Maybe<T> = T | null
 
-export type TestSuites = Readonly<{
-  testsuite?: Maybe<readonly TestSuite[]>
+export type TestSuites = {
+  testsuite?: Maybe<TestSuite[]>
   name?: Maybe<string>
   time?: Maybe<number>
   tests?: Maybe<number>
   failures?: Maybe<number>
   errors?: Maybe<number>
   disabled?: Maybe<number>
-}>
+}
 
-export type TestCase = Readonly<{
+export type TestCase = {
   name?: Maybe<string>
   classname?: Maybe<string>
   assertions?: Maybe<number>
   time?: Maybe<number>
   status?: Maybe<string>
-  skipped?: Maybe<readonly Skipped[]>
-  error?: Maybe<readonly Details[]>
-  failure?: Maybe<readonly Details[]>
+  skipped?: Maybe<Skipped[]>
+  error?: Maybe<Details[]>
+  failure?: Maybe<Details[]>
   "system-out"?: Maybe<string[]>
   "system-err"?: Maybe<string[]>
-}>
+}
 
-export type TestSuite = Readonly<{
-  testcase?: Maybe<readonly TestCase[]>
+export type TestSuite = {
+  testcase?: Maybe<TestCase[]>
   name?: Maybe<string>
   tests?: Maybe<number>
   failures?: Maybe<number>
@@ -38,14 +38,14 @@ export type TestSuite = Readonly<{
   hostname?: Maybe<string>
   id?: Maybe<string>
   package?: Maybe<string>
-  properties?: Maybe<readonly Property[]>
-  "system-out"?: Maybe<readonly string[]>
-  "system-err"?: Maybe<readonly string[]>
-}>
+  properties?: Maybe<Property[]>
+  "system-out"?: Maybe<string[]>
+  "system-err"?: Maybe<string[]>
+}
 
-export type Property = Readonly<{ name?: Maybe<string>, value?: Maybe<string> }>
-export type Skipped = Readonly<{ message?: Maybe<string> }>
-export type Details = Readonly<{ message?: Maybe<string>, type?: Maybe<string>, inner?: Maybe<string> }>
+export type Property = { name?: Maybe<string>, value?: Maybe<string> }
+export type Skipped = { message?: Maybe<string> }
+export type Details = { message?: Maybe<string>, type?: Maybe<string>, inner?: Maybe<string> }
 
 export const parse = async (xmlString: xml2js.convertableToString, xml2jsOptions?: xml2js.OptionsV2): Promise<TestSuites|TestSuite|undefined> => {
   const options = xml2jsOptions ?? {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,11 +47,12 @@ export type Property = { name?: Maybe<string>, value?: Maybe<string> }
 export type Skipped = { message?: Maybe<string> }
 export type Details = { message?: Maybe<string>, type?: Maybe<string>, inner?: Maybe<string> }
 
-export const parse = async (xmlString: xml2js.convertableToString, xml2jsOptions?: xml2js.OptionsV2): Promise<TestSuites|TestSuite|undefined> => {
+export const parse = async (xmlString: xml2js.convertableToString, xml2jsOptions?: xml2js.OptionsV2): Promise<TestSuites|TestSuite|undefined|null> => {
   const options = xml2jsOptions ?? {
     attrValueProcessors: [xml2js.processors.parseNumbers]
   }
   const result = await xml2js.parseStringPromise(xmlString, options)
+  if (result === null) return null
 
   if ('testsuites' in result) {
     return _parse(result['testsuites']) as Promise<TestSuites>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
+    "strictNullChecks": true,                 /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
     "strictNullChecks": true,                 /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */


### PR DESCRIPTION
Thanks for this great little library!

This PR changes the TypeScript typings to always assume that a field may be `null` or `undefined`. It also declares all types and fields as immutable.

The rationale behind this change is that in practice, we cannot safely assume anything about the original XML document. This is because it isn't validated against an XML Schema or DTD before it's translated into JSON. The lack of an official schema for JUnit XML means that we cannot take anything for granted  - different tools may produce XML that lacks properties.

The proposed type changes helps users of this library anticipate that a field may be `null` or `undefined` (assuming they have set `strictNullChecks` to `true` in `tsconfig.json`. I also did that for this library, and fixed some of the tests.