### PR TITLE
Fix parsing of properties

### DIFF
--- a/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -6,11 +6,7 @@ Object {
   "failures": 0,
   "hostname": "fv-az88",
   "name": "com.google.samples.apps.sunflower.RobolectricGardenActivityTest2",
-  "properties": Array [
-    Object {
-      "inner": "",
-    },
-  ],
+  "properties": Array [],
   "skipped": 0,
   "system-err": Array [
     "[Robolectric] WARN: Android SDK 29 requires Java 9 (have Java 8). Tests won't be run on SDK 29 unless explicitly requested.

--- a/__tests__/basic.test.ts
+++ b/__tests__/basic.test.ts
@@ -120,4 +120,28 @@ describe('Convert xml2js output tests', () => {
       }]
     })
   })
+
+  it('parses properties', async () => {
+    const xml = `
+    <?xml version="1.0" encoding="UTF-8"?>
+    <testsuites>
+      <testsuite>
+        <properties>
+          <property name="hello" value="bonjour"/>
+          <property name="world" value="monde"/>
+        </properties>
+      </testsuite>
+    </testsuites>
+    `
+    const parsed = await junit2json.parse(xml) as junit2json.TestSuites
+
+    expect(parsed).toEqual({
+      testsuite: [{
+        properties: [
+          {name: "hello", value: "bonjour"},
+          {name: "world", value: "monde"}
+        ]
+      }]
+    })
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,9 @@ const _parse = (objOrArray: ObjOrArray): ObjOrArray => {
     else if (key === 'system-out' || key === 'system-err') {
       output[key] = nested.map((inner: string) => inner)
     }
+    else if (key === 'properties') {
+      output[key] = _parse(nested[0]?.property || [])
+    }
     else if (typeof(nested) === 'object') {
       output[key] = _parse(nested)
     }


### PR DESCRIPTION
This fixes parsing of `<properties>`. The value stored on `TestSuite.properties` did not match the TypeScript type. This PR fixes that.