### PR TITLE
Fix earthly/actions-setup API limit exceeded error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: earthly/actions-setup@v1.0.2
         with:
           version: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
         with:
           ref: master


### PR DESCRIPTION
Passing GITHUB_TOKEN will prevent API limit exceeded error.
https://github.com/earthly/actions-setup/blob/0f27e887233593666346cf20e138c06085f9d18c/src/lib/get-version.ts#L16