### PR TITLE
Bump Nodejs to v20

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-20",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-from-docker:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,10 @@ jobs:
   test:
     strategy:
       matrix:
-        container: ["node:current", "node:lts"]
+        container:
+          # - "node:current"
+          - "node:lts"
+          - "node:20"
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -33,7 +36,10 @@ jobs:
   cli_test:
     strategy:
       matrix:
-        container: ["node:current", "node:lts"]
+        container:
+          # - "node:current"
+          - "node:lts"
+          - "node:20"
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/Earthfile
+++ b/Earthfile
@@ -1,6 +1,6 @@
 VERSION 0.7
 
-FROM node:18.18.1
+FROM node:20.8.1
 WORKDIR /build
 
 build:


### PR DESCRIPTION
Bump Nodejs that used in dev environment to v20.

Node.js v21 has just appeared and CI is failing, so we have temporarily disabled `node:current`.