### PR TITLE
Enable npm publish --provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,15 @@ jobs:
         run: |
           export TAG_NAME=${{ needs.draft_release.outputs.tag_name }}
           echo "VERSION=${TAG_NAME:1}" >> $GITHUB_ENV
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
       - uses: earthly/actions-setup@v1.0.13
         with:
           version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v4
-        with:
-          ref: master
 
       # Use GitHub App for bypassing ruleset guard when git push by npm publish
       - uses: actions/create-github-app-token@v1
@@ -43,12 +45,21 @@ jobs:
         with:
           app-id: ${{ secrets.BYPASS_APP_ID }}
           private-key: ${{ secrets.BYPASS_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Setup git config
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
       # npm publish and push updated package.json
       - name: Publish
         run: |
           npm run release -- --VERSION=$VERSION
+          git push origin master
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
       # Publish github releases. Also tag will be created.

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -1,0 +1,42 @@
+name: Prepublish for release test
+on:
+  workflow_dispatch:
+jobs:
+  prerelease:
+    runs-on: ubuntu-latest
+    environment:
+        name: dev
+        url: https://www.npmjs.com/package/junit2json
+    permissions:
+      contents: write
+      id-token: write
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - uses: earthly/actions-setup@v1.0.13
+        with:
+          version: latest
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup git config
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      # npm publish and push updated package.json
+      - name: PrePublish
+        run: |
+          npm run release:prepublish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
+      - name: Commit and push changes
+        run: |
+          git add package*.json
+          git commit -m "debug: npm run release:prepublish"
+          git push

--- a/Earthfile
+++ b/Earthfile
@@ -17,13 +17,13 @@ prepublish:
   LOCALLY
   COPY +build/dist dist/
   RUN npm version prerelease --no-git-tag-version && \
-      npm publish --tag=beta
+      npm publish --provenance --tag=beta
 
 publish:
   LOCALLY
   ARG --required VERSION
   COPY +build/dist dist/
   RUN npm version $VERSION && \
-      # npm publish
+      # npm publish --provenance
       npm publish --dry-run
   # RUN git push origin master

--- a/Earthfile
+++ b/Earthfile
@@ -24,6 +24,4 @@ publish:
   ARG --required VERSION
   COPY +build/dist dist/
   RUN npm version $VERSION && \
-      # npm publish --provenance
-      npm publish --dry-run
-  # RUN git push origin master
+      npm publish --provenance

--- a/Earthfile
+++ b/Earthfile
@@ -13,17 +13,10 @@ build:
   SAVE ARTIFACT dist/ dist
 
 publish:
-  RUN --no-cache --secret GITHUB_TOKEN \
-      git clone --depth=1 --branch=master https://github.com/Kesin11/ts-junit2json.git && \
-      git config --global user.name "github-actions" && \
-      git config --global user.email "github-actions@github.com" && \
-      git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-  WORKDIR ts-junit2json
-
+  LOCALLY
   ARG --required VERSION
   COPY +build/dist dist/
-  RUN --no-cache --secret NODE_AUTH_TOKEN \
-      echo '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' > $HOME/.npmrc && \
-      npm version $VERSION && \
-      npm publish
-  RUN --no-cache --secret GITHUB_TOKEN git push origin master
+  RUN npm version $VERSION && \
+      # npm publish
+      npm publish --dry-run
+  # RUN git push origin master

--- a/Earthfile
+++ b/Earthfile
@@ -12,6 +12,13 @@ build:
   RUN npm run build
   SAVE ARTIFACT dist/ dist
 
+# Test publishing from local purpose
+prepublish:
+  LOCALLY
+  COPY +build/dist dist/
+  RUN npm version prerelease --no-git-tag-version && \
+      npm publish --tag=beta
+
 publish:
   LOCALLY
   ARG --required VERSION

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "integrate_test": "node --test integrate_tests/",
-    "release:prepublish": "npm run clean && npm run build && npm version prerelease --no-git-tag-version && npm publish --tag=beta",
+    "release:prepublish": "earthly +prepublish",
     "release": "earthly +publish"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:watch": "jest --watch",
     "integrate_test": "node --test integrate_tests/",
     "release:prepublish": "npm run clean && npm run build && npm version prerelease --no-git-tag-version && npm publish --tag=beta",
-    "release": "earthly --secret NODE_AUTH_TOKEN --secret GITHUB_TOKEN +publish"
+    "release": "earthly +publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
To enable [provenance feature](https://docs.npmjs.com/generating-provenance-statements), migrate publishing package from Earthly buildkit to GitHub Actions VM directly.