### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - "master"
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Kesin11/ts-junit2json/security/code-scanning/9](https://github.com/Kesin11/ts-junit2json/security/code-scanning/9)

To fix the issue, we will add a `permissions` block to the workflow. Since the `test` and `cli_test` jobs do not appear to require write access to the repository, we will set the permissions to `contents: read` at the workflow level. This will apply to all jobs in the workflow unless overridden. If any job requires additional permissions, we can define a specific `permissions` block for that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
