### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   draft_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       tag_name: ${{ steps.release-drafter.outputs.tag_name }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Kesin11/ts-junit2json/security/code-scanning/2](https://github.com/Kesin11/ts-junit2json/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `draft_release` job. Based on the functionality of the `release-drafter` action, it only requires read access to the repository contents. Therefore, we will set `contents: read` as the permission for this job. This change ensures that the job adheres to the principle of least privilege while maintaining its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
