### PR TITLE
Fix invalid 'npm run release' argument

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       # npm publish and push updated package.json
       - name: Publish to npm and jsr
         run: |
-          npm run release -- --VERSION=$VERSION
+          npm run release -- $VERSION
           git push origin master
 
       # Publish github releases. Also tag will be created.


### PR DESCRIPTION
Fix invalid argument format introduced when removing Earthly in #385.