### PR TITLE
Allow Reading from Standard Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,17 +141,20 @@ npx junit2json -p -f system-out,system-err junit.xml
 junit2json - Convert JUnit XML format to JSON
 
 Positionals:
-  path  JUnit XML path                                                  [string]
+  path  JUnit XML path (use '-' for stdin)                             [string]
 
 Options:
       --help                        Show help                          [boolean]
       --version                     Show version number                [boolean]
   -p, --pretty                      Output pretty JSON[boolean] [default: false]
-  -f, --filter-tags                 Filter XML tag names                [string]
+  -f, --filter-tags                 Filter XML tag names               [string]
 
 Examples:
-  cli.js -p -f system-out,system-err        Output pretty JSON with filter
-  junit.xml                                 <system-out> and <system-err> tags.
+  # Output pretty JSON with filter <system-out> and <system-err> tags.
+  npx junit2json -p -f system-out,system-err junit.xml
+
+  # Pipe node --test junit output into junit2json
+  node --test --test-reporter=junit ... | npx junit2json -p -
 ```
 
 ## CLI with `jq` examples

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ const printHelp = () => {
   const help = `junit2json - Convert JUnit XML format to JSON
 
 Positionals:
-  path  JUnit XML path                                                  [string]
+  path  JUnit XML path (use '-' for stdin)                             [string]
 
 Options:
       --help                        Show help                          [boolean]
@@ -60,7 +60,8 @@ const main = async () => {
     process.exit(1)
   }
 
-  const xmlString = fs.readFileSync(inputPath, 'utf8').toString()
+  const nameOrDesc: number|string = (inputPath === '-') ? 0 : inputPath;
+  const xmlString = fs.readFileSync(nameOrDesc, 'utf8').toString()
 
   const filterTags = typeof values['filter-tags'] === 'string' && values['filter-tags'].length > 0
     ? values['filter-tags'].split(',')


### PR DESCRIPTION
## Description
Allow piping stdin into junit2xml by making cli program read from stdin when junit.xml is specified as '-' .

The use of '-' is consistent with many other CLI utilities.

## Motivation
Allow converting output of programs like `node --test --test-reporter=junit ...`  to JSON without needing to create a temporary file.

## Example
Run this project's tests as
```
 node --test --test-reporter=junit 'tests/**/*.test.ts' | npx junit2json -p -
```