### PR TITLE
Migrate build config for TypeScript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/node": "24.10.13",
         "tsconfig-to-dual-package": "^1.2.0",
-        "typescript": "5.9.3"
+        "typescript": "6.0.2"
       }
     },
     "node_modules/@types/node": {
@@ -77,10 +77,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -154,9 +155,9 @@
       }
     },
     "typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
   "devDependencies": {
     "@types/node": "24.10.13",
     "tsconfig-to-dual-package": "^1.2.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.2"
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "module": "CommonJS",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "outDir": "./dist/cjs/",
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist/esm/",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./lib",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDir": "./src",                        /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
@@ -44,7 +44,7 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
+    "types": ["node"],                       /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */


### PR DESCRIPTION
## Summary
- update `typescript` to `6.0.2`
- add an explicit `rootDir` and `types: ["node"]` to match TypeScript 6 config defaults
- replace deprecated `moduleResolution: "node"` in the CommonJS config with `"bundler"`

## Why
PR #416 only updates the dependency version, but CI fails in `cli_test` during `npm run build` after upgrading to TypeScript 6.

TypeScript 6 changed tsconfig behavior in a few places that affect this repository:
- `rootDir` now defaults differently, which breaks this package's output layout unless it is set explicitly
- `types` now defaults to `[]`, so Node types should be declared explicitly for predictable builds
- `moduleResolution: "node"` is deprecated and errors in this project's CJS config on TS 6

## Verification
- `npm run build`
- `npm run test`
- `npm run integrate_test`

Supersedes #416.